### PR TITLE
Fix timezone handling in today command

### DIFF
--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -187,8 +187,9 @@ async function fetchTimeEntries(
   startDate: string,
   endDate: string
 ): Promise<TogglTimeEntry[]> {
-  const start = dayjs(startDate).format('YYYY-MM-DD')
-  const end = dayjs(endDate).format('YYYY-MM-DD')
+  // Use full ISO timestamps to ensure proper timezone handling
+  const start = encodeURIComponent(startDate)
+  const end = encodeURIComponent(endDate)
 
   return await client.get(`/me/time_entries?start_date=${start}&end_date=${end}`)
 }


### PR DESCRIPTION
## Summary
- Fixed timezone handling issue in the `today` command where entries before 8am might not be displayed
- Changed date parameter formatting to use full ISO 8601 timestamps instead of YYYY-MM-DD format
- Ensures all entries for the user's local "today" are returned correctly regardless of timezone

## Problem
The `today` command was converting ISO timestamps to simple date strings (`YYYY-MM-DD`) before sending them to the Toggl API. This could cause timezone-related issues where the API might interpret the dates differently based on server timezone settings, potentially excluding early morning entries.

## Solution
Now passes the full ISO 8601 timestamps (with timezone information) directly to the API, properly URL-encoded. This ensures consistent behavior across all timezones.

## Test Plan
- [x] Verified that entries before 8am now appear correctly
- [x] Tested with multiple time entries throughout the day
- [x] Confirmed total time calculation is accurate
- [x] Project summary displays correctly