### PR TITLE
fix: correct edit command API endpoint to use workspace-scoped path

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -90,7 +90,7 @@ export function createEditCommand(): Command {
         throw new Error(`Invalid update data: ${validatedUpdates.summary}`)
       }
 
-      const updatedTimer = await updateTimer(client, currentTimer.id, validatedUpdates)
+      const updatedTimer = await updateTimer(client, currentTimer, validatedUpdates)
 
       // Step 7: Show success and changes
       console.log('')
@@ -277,9 +277,14 @@ async function collectEdits(
  */
 async function updateTimer(
   client: ReturnType<typeof createTogglClient>,
-  timerId: number,
+  timer: TogglTimeEntry,
   updates: TimerUpdateData
 ): Promise<TogglTimeEntry> {
+  // Validate timer has required IDs
+  if (!timer.workspace_id || !timer.id) {
+    throw new Error('Timer missing required workspace ID or timer ID. Unable to update timer.')
+  }
+
   // Convert validated updates to the format expected by the API
   const updateData: Record<string, unknown> = {}
 
@@ -295,7 +300,7 @@ async function updateTimer(
     updateData.task_id = updates.task_id
   }
 
-  return await client.put(`/me/time_entries/${timerId}`, updateData)
+  return await client.put(`/workspaces/${timer.workspace_id}/time_entries/${timer.id}`, updateData)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed the edit command which was failing with "API error 405: Method Not Allowed"
- Updated API endpoint from `/me/time_entries/${timerId}` to `/workspaces/${workspaceId}/time_entries/${timerId}`
- Improved function signature to accept timer object instead of separate IDs

## Root Cause
The edit command was using an incorrect API endpoint that doesn't exist or doesn't support PUT method in Toggl API v9. The workspace-scoped endpoint is required for updating time entries.

## Changes Made
- Updated `updateTimer` function to accept timer object instead of separate timerId parameter
- Added validation for required workspace_id and timer ID within the function
- Fixed API endpoint to use workspace-scoped path consistent with other commands (e.g., stop command)

## Test Plan
- [x] Code compiles successfully with `yarn build`
- [x] All existing tests pass with `yarn test`
- [x] Function signature is cleaner and more consistent with project patterns

The edit command should now work properly without the 405 Method Not Allowed error.