### PR TITLE
fix: add billable status inheritance from projects to new time entries

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -280,6 +280,7 @@ export interface TogglProject {
   active: boolean
   workspace_id: number
   client_id?: number
+  billable: boolean
 }
 
 export interface TogglTask {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -43,6 +43,7 @@ const StartTimerDataSchema = type({
   task_id: 'number?',
   workspace_id: 'number',
   created_with: 'string',
+  billable: 'boolean?',
 })
 
 /**
@@ -112,6 +113,7 @@ export function createStartCommand(): Command {
         start: dayjs().toISOString(), // Current time as start time
         workspace_id: workspaceId,
         created_with: 'tog-cli',
+        billable: selectedProject?.billable ?? false, // Inherit billable status from project
       }
 
       if (selectedProject) {


### PR DESCRIPTION
## Summary
- Fixed new time entries to properly inherit billable status from their associated project
- Ensures billing accuracy when creating timers through the CLI
- Follows standard Toggl behavior for project-to-time-entry inheritance

## Problem
Previously, new time entries created via `tog start` would always have `billable: false` regardless of the project's billable status. This caused loss of important billing information and required manual correction in the Toggl web interface.

## Solution
- **Added billable field** to `TogglProject` interface for proper TypeScript typing
- **Updated schema** to include optional `billable` field in `StartTimerDataSchema`
- **Implemented inheritance logic**: `billable: selectedProject?.billable ?? false`

## Behavior
- ✅ Time entries with billable projects → marked as billable
- ✅ Time entries without projects → remain non-billable (false)
- ✅ Time entries with non-billable projects → remain non-billable (false)

## Test Plan
- [x] Code compiles successfully with `yarn build`
- [x] All existing tests pass with `yarn test`
- [x] TypeScript properly types the billable field
- [x] Logic correctly inherits from project or defaults to false

This ensures that billing information is preserved when creating time entries, reducing manual work and improving accuracy for billable client work.